### PR TITLE
Fix UI min-height bug

### DIFF
--- a/process-manager.html
+++ b/process-manager.html
@@ -10,6 +10,7 @@
     }
     .process-table-container {
       overflow-x: scroll;
+      flex: 2;
     }
   </style>
 </head>


### PR DESCRIPTION
## Issue

The scroll container didn’t fill the entire height of the browser window.
So the x-scrollbar was in the middle of the screen.

Electron Version: 2.0.2
Operating System: MacOS 10.13.4 

**Before fix**

<img width="456" alt="bildschirmfoto 2018-06-13 um 13 21 03" src="https://user-images.githubusercontent.com/1265681/41348329-a46ce0bc-6f0c-11e8-910a-83f718fb43ef.png">

**After fix**

<img width="456" alt="bildschirmfoto 2018-06-13 um 13 22 10" src="https://user-images.githubusercontent.com/1265681/41348409-cc37ab54-6f0c-11e8-8f30-2d18a0cb1c3b.png">





