### PR TITLE
openDevTools({detach: true}) is deprecated in electron 3.0. We should…

### DIFF
--- a/src/ProcessManager.js
+++ b/src/ProcessManager.js
@@ -39,7 +39,7 @@ class ProcessManager extends EventEmitter {
     this.emit('will-open-dev-tools', webContentsId, this.window);
 
     const wc = webContents.fromId(webContentsId);
-    wc.openDevTools({ detached: true });
+    wc.openDevTools({mode: 'detach'});
 
     this.emit('did-open-dev-tools', webContentsId, this.window);
   }


### PR DESCRIPTION
… use openDevTools({mode: 'detach'})

Using electron 3.0.x-beta.7 and keeping {detach: true} make weird stuff and finish to freeze the application. 

{detach: true} is deprecated too.

maybe https://github.com/getstation/electron-process-manager/issues/5 is related to this ?