### PR TITLE
Electron 10 - Fix missing `remote` module 

### DIFF
--- a/src/ProcessManagerWindow.js
+++ b/src/ProcessManagerWindow.js
@@ -12,6 +12,7 @@ class ProcessManagerWindow extends BrowserWindow {
       webPreferences: {
         nodeIntegration: true,
         webviewTag: true,
+        enableRemoteModule: true,
       }
     }, options || {});
 


### PR DESCRIPTION
Needed to add `enableRemoteModule: true` to the BrowserWindow webPreferences.
The default value has changed to `false`.

